### PR TITLE
[core] Queue the message when sending USER_ERROR

### DIFF
--- a/src/main/java/uk/co/markg/clerky/command/Setup.java
+++ b/src/main/java/uk/co/markg/clerky/command/Setup.java
@@ -52,7 +52,7 @@ public class Setup {
   public void setup(DiscordRequest request, CategoryRequest args) {
 
     if (args.maxUsers > 99 || args.maxUsers <= 0) {
-      request.getEvent().getChannel().sendMessage(USER_ERROR);
+      request.getEvent().getChannel().sendMessage(USER_ERROR).queue();
       return;
     }
 


### PR DESCRIPTION
### Description of Problem

The code appeared to want to send a message upon validation of the arguments of `maxUsers` whether it was greater than 99 or less than or equal to 0.  This would return the command early before setting-up as a sort of request error.  While this code seems correct, looking at the [docs](https://ci.dv8tion.net/job/JDA/javadoc/net/dv8tion/jda/api/requests/RestAction.html) it would seem that we either have to `queue` or `complete` the `RestAction` in order to actually execute the `sendMessage` call.  This is supported by the following `sendMessage` call that *does* use the `queue` action to submit the actual message.

### Expected Behavior

When I set `args.maxUsers` which is flag `-u` or `--users` to a number <= 0 or > 99 I will see a message telling me:

```
Max users must be greater than 0 and less than or equal to 99
```

### Actual Behavior

When I set `args.maxUsers` which is flag `-u` or `--users` to a number <= 0 or > 99 I do not see a message telling me:

```
Max users must be greater than 0 and less than or equal to 99
```

However, the set-up does early return and nothing actually gets set-up, there is just no feedback for why this number is not allowed to be set.

### This PR

This PR should fix the problem by finishing the `sendMessage` call with a complete action such as `queue`.  Now, the user will receive feedback that they did not set valid values for `args.maxUsers`!